### PR TITLE
6 user story

### DIFF
--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -1,6 +1,6 @@
 class DealershipsController < ApplicationController
   def index
-    @dealerships = Dealership.all
+    @dealerships = Dealership.all.order(created_at: :desc)
   end
 
   def show

--- a/app/views/dealerships/index.html.erb
+++ b/app/views/dealerships/index.html.erb
@@ -1,3 +1,4 @@
 <% @dealerships.each do |dealership| %>
-  <p><%= dealership.name %></p>
+  <p><%= dealership.name %>
+  <%= dealership.created_at %></p>
 <% end %>

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -2,13 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "/dealerships", type: :feature do
   describe "as a visitor, when I visit the dealership index page" do
-    let(:dealer1) { "Mountain States Toyota" }
-    let(:dealer2) { "Stevinson Automotive" }
-    let(:dealer3) { "Mom&Pop Auto Shop" }
     before :each do 
       @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
       @dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
-      @dealership_3 = Dealership.create!(name: "Mom&Pop Auto Shop", financing_available: false, employees: 2)
+      @dealership_3 = Dealership.create!(name: "Mom and Pop Auto Shop", financing_available: false, employees: 2)
       visit "/dealerships"
     end
     it "should display the name of each dealerships" do
@@ -17,15 +14,12 @@ RSpec.describe "/dealerships", type: :feature do
       expect(page).to have_content(@dealership_3.name)
     end
 
-    xit "should be ordered starting with most recently created" do
-      save_and_open_page
-
-      expect(:dealer3).to appear_before(:dealer2)
-      expect(:dealer2).to appear_before(:dealer1)
+    it "should be ordered starting with most recently created" do
+      expect(@dealership_3.name).to appear_before(@dealership_2.name)
+      expect(@dealership_2.name).to appear_before(@dealership_1.name)
     end
 
     it "should display created at timestamps" do
-      save_and_open_page
       expect(page).to have_content(@dealership_1.created_at)
       expect(page).to have_content(@dealership_2.created_at)
       expect(page).to have_content(@dealership_3.created_at)

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -2,15 +2,40 @@ require 'rails_helper'
 
 RSpec.describe "/dealerships", type: :feature do
   describe "as a visitor, when I visit the dealership index page" do
-    it "should display the name of each dealerships" do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
-      dealership_3 = Dealership.create!(name: "Mom&Pop Auto Shop", financing_available: false, employees: 2)
+    let(:dealer1) { "Mountain States Toyota" }
+    let(:dealer2) { "Stevinson Automotive" }
+    let(:dealer3) { "Mom&Pop Auto Shop" }
+    before :each do 
+      @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+      @dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
+      @dealership_3 = Dealership.create!(name: "Mom&Pop Auto Shop", financing_available: false, employees: 2)
       visit "/dealerships"
+    end
+    it "should display the name of each dealerships" do
+      expect(page).to have_content(@dealership_1.name)
+      expect(page).to have_content(@dealership_2.name)
+      expect(page).to have_content(@dealership_3.name)
+    end
 
-      expect(page).to have_content(dealership_1.name)
-      expect(page).to have_content(dealership_2.name)
-      expect(page).to have_content(dealership_3.name)
+    xit "should be ordered starting with most recently created" do
+      save_and_open_page
+
+      expect(:dealer3).to appear_before(:dealer2)
+      expect(:dealer2).to appear_before(:dealer1)
+    end
+
+    it "should display created at timestamps" do
+      save_and_open_page
+      expect(page).to have_content(@dealership_1.created_at)
+      expect(page).to have_content(@dealership_2.created_at)
+      expect(page).to have_content(@dealership_3.created_at)
     end
   end
 end
+
+# User Story 6, Parent Index sorted by Most Recently Created 
+
+# As a visitor
+# When I visit the parent index,
+# I see that records are ordered by most recently created first
+# And next to each of the records I see when it was created

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -22,10 +22,3 @@ RSpec.describe Dealership, type: :model do
     end
   end
 end
-
-# User Story 6, Parent Index sorted by Most Recently Created 
-
-# As a visitor
-# When I visit the parent index,
-# I see that records are ordered by most recently created first
-# And next to each of the records I see when it was created

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -4,19 +4,28 @@ RSpec.describe Dealership, type: :model do
   describe 'relationships' do
     it { should have_many :cars }
   end
+  
+  describe '#instance methods' do
+    describe "#cars" do
+      it "returns all cars for given dealership" do
+        dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+        dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
+        car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: dealership_1.id)
+        car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: dealership_2.id)
+        car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: dealership_2.id)
+        car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: dealership_1.id)
+        car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: dealership_2.id)
 
-  describe "#cars" do
-    it "returns all cars for given dealership" do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
-      car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: dealership_1.id)
-      car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: dealership_2.id)
-      car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: dealership_2.id)
-      car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: dealership_1.id)
-      car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: dealership_2.id)
-
-      expect(dealership_1.list_cars).to eq([car_1, car_4])
-      expect(dealership_2.list_cars).to eq([car_2, car_3, car_5])
+        expect(dealership_1.list_cars).to eq([car_1, car_4])
+        expect(dealership_2.list_cars).to eq([car_2, car_3, car_5])
+      end
     end
   end
 end
+
+# User Story 6, Parent Index sorted by Most Recently Created 
+
+# As a visitor
+# When I visit the parent index,
+# I see that records are ordered by most recently created first
+# And next to each of the records I see when it was created


### PR DESCRIPTION
User Story 6, Parent Index sorted by Most Recently Created 

As a visitor
When I visit the parent index,
I see that records are ordered by most recently created first
And next to each of the records I see when it was created