### PR TITLE
10 user story

### DIFF
--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -1,3 +1,5 @@
+<p><%= link_to "Click here to view this dealership's inventory.", "/dealerships/#{@dealership.id}/cars" %></p>
+  
   <h3><%= @dealership.name %></h3>
   <p><%= @dealership.financing_available %></p>
   <p><%= @dealership.employees %></p>

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "/dealership/:id", type: :feature do
     end
 
     it 'should have a link to the child index at the top' do
-      @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
       visit "/dealerships/#{@dealership_1.id}"
 
       expect(page).to have_content("Click here to view all cars.")
@@ -39,13 +38,24 @@ RSpec.describe "/dealership/:id", type: :feature do
     end
 
     it 'should have a link to the dealerships index at the top' do
-      @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
       visit "/dealerships/#{@dealership_1.id}"
 
       expect(page).to have_content("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")
+    end
+
+    it 'should have a link to the index of cars that belong to dealership' do
+      visit "/dealerships/#{@dealership_1.id}"
+      expect(page).to have_content("Click here to view this dealership's inventory.")
+      click_link "Click here to view this dealership's inventory."
+      expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/cars")
+
+      visit "/dealerships/#{@dealership_2.id}"
+      expect(page).to have_content("Click here to view this dealership's inventory.")
+      click_link "Click here to view this dealership's inventory."
+      expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/cars")
     end
   end
 end


### PR DESCRIPTION
User Story 10, Parent Child Index Link

As a visitor
When I visit a parent show page ('/parents/:id')
Then I see a link to take me to that parent's `child_table_name` page ('/parents/:id/child_table_name')