### PR TITLE
11 user story

### DIFF
--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -11,12 +11,13 @@ class DealershipsController < ApplicationController
     
   end
 
-  # def create
-  #   dealership = Dealership.new({
-  #     title: params[:task][:title],
-  #     description: params[:task][:description]
-  #   })
-  #   task.save
-  #   redirect_to '/tasks'
-  # end
+  def create
+    dealership = Dealership.new({
+      name: params[:name],
+      financing_available: params[:financing_available],
+      employees: params[:employees]
+    })
+    dealership.save
+    redirect_to '/dealerships'
+  end
 end

--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -6,4 +6,17 @@ class DealershipsController < ApplicationController
   def show
     @dealership = Dealership.find(params[:id])
   end
+
+  def new
+    
+  end
+
+  # def create
+  #   dealership = Dealership.new({
+  #     title: params[:task][:title],
+  #     description: params[:task][:description]
+  #   })
+  #   task.save
+  #   redirect_to '/tasks'
+  # end
 end

--- a/app/views/dealerships/index.html.erb
+++ b/app/views/dealerships/index.html.erb
@@ -2,3 +2,5 @@
   <p><%= dealership.name %>
   <%= dealership.created_at %></p>
 <% end %>
+
+<p><%= link_to "New dealership.", "/dealerships/new" %></p>

--- a/app/views/dealerships/new.html.erb
+++ b/app/views/dealerships/new.html.erb
@@ -1,10 +1,9 @@
 <%= form_with url: '/dealerships', method: :post, local: true do |form| %>
   <%= form.label :name %>
-  <%= form.text_field :name %>
+  <%= form.text_field :name %><br>
   <%= form.label :financing_available %>
-  <input name="boolean-parameter" type="checkbox" value="true" />
-  <input name="boolean-parameter" type="hidden" value="false" />
+  <%= form.text_field :financing_available %><br>
   <%= form.label :employees %>
-  <%= form.text_field :employees %>
+  <%= form.text_field :employees %><br>
   <%= form.submit "Create Dealership" %>
 <% end %>

--- a/app/views/dealerships/new.html.erb
+++ b/app/views/dealerships/new.html.erb
@@ -1,0 +1,10 @@
+<%= form_with url: '/dealerships', method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+  <%= form.label :financing_available %>
+  <input name="boolean-parameter" type="checkbox" value="true" />
+  <input name="boolean-parameter" type="hidden" value="false" />
+  <%= form.label :employees %>
+  <%= form.text_field :employees %>
+  <%= form.submit "Create Dealership" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/dealerships', to: 'dealerships#index'
-  get '/dealerships/:id', to: 'dealerships#show'
+  get 'dealerships/new', to: 'dealerships#new'
   get '/cars', to: 'cars#index'
-  get '/cars/:id', to: 'cars#show'
   get '/dealerships/:dealership_id/cars', to: 'dealerships/cars#index'
+  get '/cars/:id', to: 'cars#show'
+  get '/dealerships/:id', to: 'dealerships#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get '/dealerships/:dealership_id/cars', to: 'dealerships/cars#index'
   get '/cars/:id', to: 'cars#show'
   get '/dealerships/:id', to: 'dealerships#show'
+  post '/dealerships', to: 'dealerships#create'
 end

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -38,5 +38,12 @@ RSpec.describe "/dealerships", type: :feature do
 
       expect(current_url).to eq("http://www.example.com/dealerships")
     end
+
+    it 'should have a link to a page where you can create a dealership' do
+      expect(page).to have_content("New dealership.")
+      click_link "New dealership."
+
+      expect(current_url).to eq("http://www.example.com/dealerships/new")
+    end
   end
 end

--- a/spec/features/dealerships/new_spec.rb
+++ b/spec/features/dealerships/new_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe '/dealerships/new' do
+  describe "as a visitor, when I arrive at the create new dealership page" do
+    it 'can create a new artist' do
+      visit '/dealerships/new'
+
+      fill_in(:name, with: 'County Line Auto')
+      fill_in(:financing_available, with: true)
+      fill_in(:employees, with: 10)
+      click_button('Create Dealership')
+
+      expect(current_path).to eq("/dealerships")
+      expect(page).to have_content("County Line Auto")
+    end
+  end
+end


### PR DESCRIPTION
User Story 11, Parent Creation 

As a visitor
When I visit the Parent Index page
Then I see a link to create a new Parent record, "New Parent"
When I click this link
Then I am taken to '/parents/new' where I  see a form for a new parent record
When I fill out the form with a new parent's attributes:
And I click the button "Create Parent" to submit the form
Then a `POST` request is sent to the '/parents' route,
a new parent record is created,
and I am redirected to the Parent Index page where I see the new Parent displayed.