### PR TITLE
12 user story

### DIFF
--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -8,7 +8,6 @@ class DealershipsController < ApplicationController
   end
 
   def new
-    
   end
 
   def create
@@ -20,4 +19,20 @@ class DealershipsController < ApplicationController
     dealership.save
     redirect_to '/dealerships'
   end
+
+  def edit
+    @dealership=Dealership.find(params[:dealership_id])
+  end
+
+  def update
+    dealership = Dealership.find(params[:dealership_id])
+    dealership.update({
+    name: params[:name],
+    financing_available: params[:financing_available],
+    employees: params[:employees]
+    })
+    dealership.save
+    redirect_to "/dealerships/#{dealership.id}"
+  end
+
 end

--- a/app/views/dealerships/edit.html.erb
+++ b/app/views/dealerships/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: "/dealerships/#{@dealership.id}", method: :patch, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %><br>
+  <%= form.label :financing_available %>
+  <%= form.text_field :financing_available %><br>
+  <%= form.label :employees %>
+  <%= form.text_field :employees %><br>
+  <%= form.submit "Edit Dealership" %>
+<% end %>

--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -4,3 +4,5 @@
   <p><%= @dealership.financing_available %></p>
   <p><%= @dealership.employees %></p>
   <p><%= @dealership.count_of_cars %> cars available</p>
+
+<p><%= link_to "Update Dealership.", "/dealerships/#{@dealership.id}/edit" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/dealerships', to: 'dealerships#index'
   get 'dealerships/new', to: 'dealerships#new'
+  get 'dealerships/:dealership_id/edit', to: 'dealerships#edit'
   get '/cars', to: 'cars#index'
   get '/dealerships/:dealership_id/cars', to: 'dealerships/cars#index'
   get '/cars/:id', to: 'cars#show'
   get '/dealerships/:id', to: 'dealerships#show'
   post '/dealerships', to: 'dealerships#create'
+  patch '/dealerships/:dealership_id', to: 'dealerships#update'
 end

--- a/spec/features/dealerships/edit_spec.rb
+++ b/spec/features/dealerships/edit_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe '/dealerships/:dealership_id/edit' do
+  describe "as a visitor, when I arrive at the edit dealership page" do
+    it 'can edit an existing dealership' do
+      @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+      visit "/dealerships/#{@dealership_1.id}/edit"
+
+      fill_in(:name, with: 'Different Dealership Name')
+      fill_in(:financing_available, with: false)
+      fill_in(:employees, with: 5)
+      click_button('Edit Dealership')
+
+      expect(current_path).to eq("/dealerships/#{@dealership_1.id}")
+      expect(page).to have_content("Different Dealership Name")
+      expect(page).to have_content("false")
+      expect(page).to have_content("5")
+    end
+  end
+end

--- a/spec/features/dealerships/new_spec.rb
+++ b/spec/features/dealerships/new_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe '/dealerships/new' do
   describe "as a visitor, when I arrive at the create new dealership page" do
-    it 'can create a new artist' do
+    it 'can create a new dealership' do
       visit '/dealerships/new'
 
       fill_in(:name, with: 'County Line Auto')

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -57,5 +57,17 @@ RSpec.describe "/dealership/:id", type: :feature do
       click_link "Click here to view this dealership's inventory."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/cars")
     end
+
+    it 'has a link to update the dealership' do
+      visit "/dealerships/#{@dealership_1.id}"
+      expect(page).to have_content("Update Dealership.")
+      click_link "Update Dealership."
+      expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/edit")
+
+      visit "/dealerships/#{@dealership_2.id}"
+      expect(page).to have_content("Update Dealership.")
+      click_link "Update Dealership."
+      expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/edit")
+    end
   end
 end


### PR DESCRIPTION
User Story 12, Parent Update 

As a visitor
When I visit a parent show page
Then I see a link to update the parent "Update Parent"
When I click the link "Update Parent"
Then I am taken to '/parents/:id/edit' where I  see a form to edit the parent's attributes:
When I fill out the form with updated information
And I click the button to submit the form
Then a `PATCH` request is sent to '/parents/:id',
the parent's info is updated,
and I am redirected to the Parent's Show page where I see the parent's updated info