### PR TITLE
13 user story

### DIFF
--- a/app/controllers/dealerships/cars_controller.rb
+++ b/app/controllers/dealerships/cars_controller.rb
@@ -2,4 +2,20 @@
     def index
       @dealership = Dealership.find(params[:dealership_id])
     end
+
+    def new
+      @dealership = Dealership.find(params[:dealership_id])
+    end
+
+    def create
+      car = Car.new({
+        make: params[:make],
+        model: params[:model],
+        awd: params[:awd],
+        mileage: params[:mileage],
+        dealership_id: params[:dealership_id]
+      })
+      car.save
+      redirect_to "/dealerships/#{params[:dealership_id]}/cars"
+    end
   end

--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -34,5 +34,4 @@ class DealershipsController < ApplicationController
     dealership.save
     redirect_to "/dealerships/#{dealership.id}"
   end
-
 end

--- a/app/views/dealerships/cars/index.html.erb
+++ b/app/views/dealerships/cars/index.html.erb
@@ -3,3 +3,5 @@
   <p>AWD? <%= car.awd %></p>
   <p>Mileage: <%= car.mileage %></p>
 <% end %>
+
+<p><%= link_to "Add a new car.", "/dealerships/#{@dealership.id}/cars/new" %></p>

--- a/app/views/dealerships/cars/new.html.erb
+++ b/app/views/dealerships/cars/new.html.erb
@@ -1,0 +1,11 @@
+<%= form_with url: "/dealerships/#{@dealership.id}/cars", method: :post, local: true do |form| %>
+  <%= form.label :make %>
+  <%= form.text_field :make %><br>
+  <%= form.label :model %>
+  <%= form.text_field :model %><br>
+  <%= form.label :awd %>
+  <%= form.text_field :awd %><br>
+  <%= form.label :mileage %>
+  <%= form.text_field :mileage %><br>
+  <%= form.submit "Create Car" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,12 @@ Rails.application.routes.draw do
   get '/dealerships', to: 'dealerships#index'
   get 'dealerships/new', to: 'dealerships#new'
   get 'dealerships/:dealership_id/edit', to: 'dealerships#edit'
+  get 'dealerships/:dealership_id/cars/new', to: 'dealerships/cars#new'
   get '/cars', to: 'cars#index'
   get '/dealerships/:dealership_id/cars', to: 'dealerships/cars#index'
   get '/cars/:id', to: 'cars#show'
   get '/dealerships/:id', to: 'dealerships#show'
   post '/dealerships', to: 'dealerships#create'
+  post '/dealerships/:dealership_id/cars', to: 'dealerships/cars#create'
   patch '/dealerships/:dealership_id', to: 'dealerships#update'
 end

--- a/spec/features/cars/show_spec.rb
+++ b/spec/features/cars/show_spec.rb
@@ -1,12 +1,5 @@
 require 'rails_helper'
 
-# User Story 4, Child Show 
-
-# As a visitor
-# When I visit '/child_table_name/:id'
-# Then I see the child with that id including the child's attributes
-# (data from each column that is on the child table)
-
 RSpec.describe "/cars/:id", type: :feature do
   describe "as a visitor, when I visit the car show page" do
     it "should display car with that id and its attributes" do

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -58,5 +58,14 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
 
       expect(current_url).to eq("http://www.example.com/dealerships")
     end
+
+    it 'should have a link to add a new car for that dealership' do
+      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+      visit "/dealerships/#{dealership_1.id}/cars"
+      expect(page).to have_content("Add a new car.")
+      click_link "Add a new car."
+
+      expect(current_url).to eq("http://www.example.com/dealerships/#{dealership_1.id}/cars/new")
+    end
   end
 end

--- a/spec/features/dealerships/cars/new_spec.rb
+++ b/spec/features/dealerships/cars/new_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe '/dealerships/:dealership_id/cars/new' do
+  describe "as a visitor, when I arrive at the create new car page" do
+    it 'can create a new car' do
+      dealership = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+
+      visit "/dealerships/#{dealership.id}/cars/new"
+
+      fill_in(:make, with: 'Toyota')
+      fill_in(:model, with: 'Corolla')
+      fill_in(:awd, with: false)
+      fill_in(:mileage, with: 37829)
+
+      click_button('Create Car')
+
+      expect(current_path).to eq("/dealerships/#{dealership.id}/cars")
+      expect(page).to have_content("Toyota")
+      expect(page).to have_content("Corolla")
+      expect(page).to have_content("false")
+      expect(page).to have_content("37829")
+    end
+  end
+end


### PR DESCRIPTION
User Story 13, Parent Child Creation 

As a visitor
When I visit a Parent Children Index page
Then I see a link to add a new adoptable child for that parent "Create Child"
When I click the link
I am taken to '/parents/:parent_id/child_table_name/new' where I see a form to add a new adoptable child
When I fill in the form with the child's attributes:
And I click the button "Create Child"
Then a `POST` request is sent to '/parents/:parent_id/child_table_name',
a new child object/row is created for that parent,
and I am redirected to the Parent Childs Index page where I can see the new child listed