### PR TITLE
16 user story

### DIFF
--- a/app/controllers/dealerships/cars_controller.rb
+++ b/app/controllers/dealerships/cars_controller.rb
@@ -1,6 +1,7 @@
   class Dealerships::CarsController < ApplicationController
     def index
       @dealership = Dealership.find(params[:dealership_id])
+      @cars = @dealership.list_cars(params)
     end
 
     def new

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -4,4 +4,8 @@ class Car < ApplicationRecord
   def self.cars_with_awd
     Car.where(awd: true)
   end
+
+  def self.sort_alphabetically
+    Car.order(:make, :model)
+  end
 end

--- a/app/models/dealership.rb
+++ b/app/models/dealership.rb
@@ -1,8 +1,12 @@
 class Dealership < ApplicationRecord
   has_many :cars
 
-  def list_cars
-    cars.each{|car| car}
+  def list_cars(params)
+    if params[:sort] == "alphabetically"
+      @cars = Car.sort_alphabetically
+    else
+      @cars = Car.all
+    end
   end
 
   def count_of_cars

--- a/app/models/dealership.rb
+++ b/app/models/dealership.rb
@@ -2,10 +2,11 @@ class Dealership < ApplicationRecord
   has_many :cars
 
   def list_cars(params)
+    dealership_cars = Car.where(dealership_id: id)
     if params[:sort] == "alphabetically"
-      @cars = Car.sort_alphabetically
+      @cars = dealership_cars.sort_alphabetically
     else
-      @cars = Car.all
+      @cars = dealership_cars.all
     end
   end
 

--- a/app/views/dealerships/cars/index.html.erb
+++ b/app/views/dealerships/cars/index.html.erb
@@ -1,7 +1,9 @@
-<% @dealership.list_cars.each do |car| %>
-  <h3><%= "#{car.make} #{car.model}" %></h3>
-  <p>AWD? <%= car.awd %></p>
-  <p>Mileage: <%= car.mileage %></p>
-<% end %>
+  <% @cars.each do |car| %>
+    <h3><%= "#{car.make} #{car.model}" %></h3>
+    <p>AWD? <%= car.awd %></p>
+    <p>Mileage: <%= car.mileage %></p>
+  <% end %>  
 
-<p><%= link_to "Add a new car.", "/dealerships/#{@dealership.id}/cars/new" %></p>
+<p><%= link_to "Add a new car.", "/dealerships/#{@dealership.id}/cars/new" %></p><br>
+
+<p><%= link_to "Sort in alphabetical order.", "/dealerships/#{@dealership.id}/cars?sort=alphabetically" %></p><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get 'dealerships/new', to: 'dealerships#new'
   get 'dealerships/:dealership_id/edit', to: 'dealerships#edit'
   get 'dealerships/:dealership_id/cars/new', to: 'dealerships/cars#new'
+  get 'dealerships/:dealership_id/cars/sort', to: 'dealerships/cars#index'
   get '/cars', to: 'cars#index'
   get '/cars/:id/edit', to: 'cars#edit'
   get '/dealerships/:dealership_id/cars', to: 'dealerships/cars#index'

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -2,45 +2,46 @@ require 'rails_helper'
 
 RSpec.describe "/dealerships/:id/cars", type: :feature do
   describe "as a visitor, when I visit the cars page for a dealership" do
+    before :each do
+      @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
+      @dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
+      @car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: @dealership_1.id)
+      @car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: @dealership_2.id)
+      @car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: @dealership_2.id)
+      @car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: @dealership_1.id)
+      @car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: @dealership_2.id)
+      @car_6 = Car.create!(make: 'Jeep', model: 'Grand Cherokee', awd: true, mileage: 20431, dealership_id: @dealership_2.id)
+    end
     it "should display the cars that belong to dealership with that id and their attriburtes" do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
-      car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: dealership_1.id)
-      car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: dealership_2.id)
-      car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: dealership_2.id)
-      car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: dealership_1.id)
-      car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: dealership_2.id)
-      visit "/dealerships/#{dealership_1.id}/cars"
+      visit "/dealerships/#{@dealership_1.id}/cars"
 
-      expect(page).to have_content(car_1.make)
-      expect(page).to have_content(car_1.model)
-      expect(page).to have_content(car_1.awd)
-      expect(page).to have_content(car_1.mileage)
-      expect(page).to have_content(car_4.make)
-      expect(page).to have_content(car_4.model)
-      expect(page).to have_content(car_4.awd)
-      expect(page).to have_content(car_4.mileage)
+      expect(page).to have_content(@car_1.make)
+      expect(page).to have_content(@car_1.model)
+      expect(page).to have_content(@car_1.awd)
+      expect(page).to have_content(@car_1.mileage)
+      expect(page).to have_content(@car_4.make)
+      expect(page).to have_content(@car_4.model)
+      expect(page).to have_content(@car_4.awd)
+      expect(page).to have_content(@car_4.mileage)
 
-      visit "/dealerships/#{dealership_2.id}/cars"
+      visit "/dealerships/#{@dealership_2.id}/cars"
 
-      expect(page).to have_content(car_2.make)
-      expect(page).to have_content(car_2.model)
-      expect(page).to have_content(car_2.awd)
-      expect(page).to have_content(car_2.mileage)
-      expect(page).to have_content(car_3.make)
-      expect(page).to have_content(car_3.model)
-      expect(page).to have_content(car_3.awd)
-      expect(page).to have_content(car_3.mileage)
-      expect(page).to have_content(car_5.make)
-      expect(page).to have_content(car_5.model)
-      expect(page).to have_content(car_5.awd)
-      expect(page).to have_content(car_5.mileage)
+      expect(page).to have_content(@car_2.make)
+      expect(page).to have_content(@car_2.model)
+      expect(page).to have_content(@car_2.awd)
+      expect(page).to have_content(@car_2.mileage)
+      expect(page).to have_content(@car_3.make)
+      expect(page).to have_content(@car_3.model)
+      expect(page).to have_content(@car_3.awd)
+      expect(page).to have_content(@car_3.mileage)
+      expect(page).to have_content(@car_5.make)
+      expect(page).to have_content(@car_5.model)
+      expect(page).to have_content(@car_5.awd)
+      expect(page).to have_content(@car_5.mileage)
     end
 
     it 'should have a link to the cars index at the top' do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: dealership_1.id)
-      visit "/dealerships/#{dealership_1.id}/cars"
+      visit "/dealerships/#{@dealership_1.id}/cars"
 
       expect(page).to have_content("Click here to view all cars.")
       click_link "Click here to view all cars."
@@ -49,9 +50,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     end
 
     it 'should have a link to the dealerships index at the top' do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: dealership_1.id)
-      visit "/dealerships/#{dealership_1.id}/cars"
+      visit "/dealerships/#{@dealership_1.id}/cars"
 
       expect(page).to have_content("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
@@ -60,12 +59,29 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     end
 
     it 'should have a link to add a new car for that dealership' do
-      dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      visit "/dealerships/#{dealership_1.id}/cars"
+      visit "/dealerships/#{@dealership_1.id}/cars"
       expect(page).to have_content("Add a new car.")
       click_link "Add a new car."
 
-      expect(current_url).to eq("http://www.example.com/dealerships/#{dealership_1.id}/cars/new")
+      expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/cars/new")
+    end
+
+    it 'should have a link to sort cars in alphabetical order' do
+      visit "/dealerships/#{@dealership_2.id}/cars"
+      expect(page).to have_content("Sort in alphabetical order.")
+      click_link "Sort in alphabetical order."
+
+      expect(current_path).to eq("/dealerships/#{@dealership_2.id}/cars")
+      expect(@car_5.make).to appear_before(@car_2.make)
+      expect(@car_2.make).to appear_before(@car_3.make)
+    end
+    
+    it 'should sort alphabetically by model if make is the same' do
+      visit "/dealerships/#{@dealership_2.id}/cars"
+      expect(page).to have_content("Sort in alphabetical order.")
+      click_link "Sort in alphabetical order."
+
+      expect(@car_5.model).to appear_before(@car_6.model)
     end
   end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
       @car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: @dealership_1.id)
       @car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: @dealership_2.id)
       @car_6 = Car.create!(make: 'Jeep', model: 'Grand Cherokee', awd: true, mileage: 20431, dealership_id: @dealership_2.id)
+      @car_7 = Car.create!(make: 'Ford', model: 'Bronco', awd: true, mileage: 204393, dealership_id: @dealership_1.id)
     end
     it "should display the cars that belong to dealership with that id and their attriburtes" do
       visit "/dealerships/#{@dealership_1.id}/cars"
@@ -23,6 +24,10 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
       expect(page).to have_content(@car_4.model)
       expect(page).to have_content(@car_4.awd)
       expect(page).to have_content(@car_4.mileage)
+
+      expect(page).to have_no_content(@car_2.make)
+      expect(page).to have_no_content(@car_2.model)
+      expect(page).to have_no_content(@car_2.mileage)
 
       visit "/dealerships/#{@dealership_2.id}/cars"
 
@@ -38,6 +43,10 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
       expect(page).to have_content(@car_5.model)
       expect(page).to have_content(@car_5.awd)
       expect(page).to have_content(@car_5.mileage)
+
+      expect(page).to have_no_content(@car_4.make)
+      expect(page).to have_no_content(@car_4.model)
+      expect(page).to have_no_content(@car_4.mileage)
     end
 
     it 'should have a link to the cars index at the top' do
@@ -77,8 +86,13 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     end
     
     it 'should sort alphabetically by model if make is the same' do
+      visit "/dealerships/#{@dealership_1.id}/cars"
+      click_link "Sort in alphabetical order."
+
+      expect(current_path).to eq("/dealerships/#{@dealership_1.id}/cars")
+      expect(@car_1.model).to appear_before(@car_4.model)
+
       visit "/dealerships/#{@dealership_2.id}/cars"
-      expect(page).to have_content("Sort in alphabetical order.")
       click_link "Sort in alphabetical order."
 
       expect(@car_5.model).to appear_before(@car_6.model)

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -17,12 +17,16 @@ RSpec.describe Car, type: :model do
     end
     describe '::cars_with_awd' do
       it 'returns an array of cars with awd' do
-        assert(Car.cars_with_awd, [@car2, @car_4])
+        results = Car.cars_with_awd
+        expected = [@car_2, @car_4, @car_5]
+        assert_equal(results, expected)
       end
     end
     describe '::sort_alphabetically' do
       it 'returns an array of cars sorted by alphabetical order' do
-        assert(Car.sort_alphabetically, [@car_5,@car_2,@car_3,@car_1,@car_4])
+        results = Car.sort_alphabetically
+        expected = [@car_5,@car_2,@car_3,@car_1,@car_4]
+        assert_equal(results, expected)
       end
     end
   end

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -8,17 +8,21 @@ RSpec.describe Car, type: :model do
   describe '::class methods' do
     before :each do
       @dealership_1 = Dealership.create!(name: "Mountain States Toyota", financing_available: true, employees: 100)
-      @dealership_2 = Dealership.create!(name: "Stevinson Automotive", financing_available: true, employees: 300)
-      @dealership_3 = Dealership.create!(name: "Mom&Pop Auto Shop", financing_available: false, employees: 2)
 
       @car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: @dealership_1.id)
-      @car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: @dealership_2.id)
-      @car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: @dealership_3.id)
-      @car_4 = Car.create!(make: 'Subaru', model: 'Outback', awd: true, mileage: 250234, dealership_id: @dealership_2.id)
+      @car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: @dealership_1.id)
+      @car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: @dealership_1.id)
+      @car_4 = Car.create!(make: 'Toyota', model: 'Highlander', awd: true, mileage: 80854, dealership_id: @dealership_1.id)
+      @car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: @dealership_1.id)
     end
     describe '::cars_with_awd' do
       it 'returns an array of cars with awd' do
         assert(Car.cars_with_awd, [@car2, @car_4])
+      end
+    end
+    describe '::sort_alphabetically' do
+      it 'returns an array of cars sorted by alphabetical order' do
+        assert(Car.sort_alphabetically, [@car_5,@car_2,@car_3,@car_1,@car_4])
       end
     end
   end

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -26,19 +26,23 @@ RSpec.describe Dealership, type: :model do
     describe '#list_cars' do
       it 'returns alphabetical list of cars if query specifies' do
         params = {sort: "alphabetically"}
-        expected = @dealership_1.list_cars(params)
-        assert_equal(expected,[@car_1,@car_4])
+        results = @dealership_1.list_cars(params)
+        expected = [@car_1,@car_4]
+        assert_equal(results, expected)
 
-        expected = @dealership_2.list_cars(params)
-        assert_equal(expected,[@car_5,@car_2,@car_3])
+        results = @dealership_2.list_cars(params)
+        expected = [@car_5,@car_2,@car_3]
+        assert_equal(results, expected)
       end
       it 'returns list of cars without query' do
         params = {blank: "blank"}
-        expected = @dealership_1.list_cars(params)
-        assert_equal(expected, [@car_1,@car_4])
+        results = @dealership_1.list_cars(params)
+        expected = [@car_1,@car_4]
+        assert_equal(results, expected)
 
-        expected = @dealership_2.list_cars(params)
-        assert_equal(expected, [@car_2,@car_3,@car_5])
+        results = @dealership_2.list_cars(params)
+        expected = [@car_2,@car_3,@car_5]
+        assert_equal(results, expected)
       end
     end
   end

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -24,14 +24,21 @@ RSpec.describe Dealership, type: :model do
     end
     
     describe '#list_cars' do
-      it 'returns list of dealerships cars based on query' do
+      it 'returns alphabetical list of cars if query specifies' do
         params = {sort: "alphabetically"}
-        assert(@dealership_1.list_cars(params), [@car_1,@car_4])
-        assert(@dealership_2.list_cars(params), [@car_5,@car_2,@car_3,@car_1,@car_4])
+        expected = @dealership_1.list_cars(params)
+        assert_equal(expected,[@car_1,@car_4])
 
+        expected = @dealership_2.list_cars(params)
+        assert_equal(expected,[@car_5,@car_2,@car_3])
+      end
+      it 'returns list of cars without query' do
         params = {blank: "blank"}
-        assert(@dealership_1.list_cars(params), [@car_1,@car_4])
-        assert(@dealership_2.list_cars(params), [@car_5,@car_2,@car_3])
+        expected = @dealership_1.list_cars(params)
+        assert_equal(expected, [@car_1,@car_4])
+
+        expected = @dealership_2.list_cars(params)
+        assert_equal(expected, [@car_2,@car_3,@car_5])
       end
     end
   end

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -16,17 +16,22 @@ RSpec.describe Dealership, type: :model do
       @car_5 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: @dealership_2.id)
     end
     
-    describe "#cars" do
-      it "returns all cars for given dealership" do
-        expect(@dealership_1.list_cars).to eq([@car_1, @car_4])
-        expect(@dealership_2.list_cars).to eq([@car_2, @car_3, @car_5])
-      end
-    end
-
     describe '#count_of_cars' do
       it 'returns number of cars with dealership as parent' do
         expect(@dealership_1.count_of_cars).to eq 2
         expect(@dealership_2.count_of_cars).to eq 3
+      end
+    end
+    
+    describe '#list_cars' do
+      it 'returns list of dealerships cars based on query' do
+        params = {sort: "alphabetically"}
+        assert(@dealership_1.list_cars(params), [@car_1,@car_4])
+        assert(@dealership_2.list_cars(params), [@car_5,@car_2,@car_3,@car_1,@car_4])
+
+        params = {blank: "blank"}
+        assert(@dealership_1.list_cars(params), [@car_1,@car_4])
+        assert(@dealership_2.list_cars(params), [@car_5,@car_2,@car_3])
       end
     end
   end


### PR DESCRIPTION
User Story 16, Sort Parent's Children in Alphabetical Order by name 

As a visitor
When I visit the Parent's children Index Page
Then I see a link to sort children in alphabetical order
When I click on the link
I'm taken back to the Parent's children Index Page where I see all of the parent's children in alphabetical order