### PR TITLE
17 user story

### DIFF
--- a/app/views/dealerships/index.html.erb
+++ b/app/views/dealerships/index.html.erb
@@ -1,6 +1,7 @@
 <% @dealerships.each do |dealership| %>
   <p><%= dealership.name %>
-  <%= dealership.created_at %></p>
+  <%= link_to "Click to edit #{dealership.name}.", "/dealerships/#{dealership.id}/edit"%><br>
+  <%= "Created at: #{dealership.created_at}" %></p>
 <% end %>
 
 <p><%= link_to "New dealership.", "/dealerships/new" %></p>

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe "/cars", type: :feature do
     end
 
     it 'should have a link to the cars index at the top' do
-      expect(page).to have_content("Click here to view all cars.")
+      expect(page).to have_link("Click here to view all cars.")
       click_link "Click here to view all cars."
 
       expect(current_url).to eq("http://www.example.com/cars")
     end
 
     it 'should have a link to the dealerships index at the top' do
-      expect(page).to have_content("Click here to view all dealerships.")
+      expect(page).to have_link("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")

--- a/spec/features/cars/show_spec.rb
+++ b/spec/features/cars/show_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "/cars/:id", type: :feature do
     it 'should have a link to the cars index at the top' do
       visit "/cars/#{@car_1.id}"
 
-      expect(page).to have_content("Click here to view all cars.")
+      expect(page).to have_link("Click here to view all cars.")
       click_link "Click here to view all cars."
 
       expect(current_url).to eq("http://www.example.com/cars")
@@ -46,7 +46,7 @@ RSpec.describe "/cars/:id", type: :feature do
     it 'should have a link to the dealerships index at the top' do
       visit "/cars/#{@car_1.id}"
 
-      expect(page).to have_content("Click here to view all dealerships.")
+      expect(page).to have_link("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")
@@ -54,7 +54,7 @@ RSpec.describe "/cars/:id", type: :feature do
 
     it 'has a link to update the car' do
       visit "/cars/#{@car_1.id}"
-      expect(page).to have_content("Update Car.")
+      expect(page).to have_link("Update Car.")
       click_link "Update Car."
       expect(current_url).to eq("http://www.example.com/cars/#{@car_1.id}/edit")
     end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     it 'should have a link to the cars index at the top' do
       visit "/dealerships/#{@dealership_1.id}/cars"
 
-      expect(page).to have_content("Click here to view all cars.")
+      expect(page).to have_link("Click here to view all cars.")
       click_link "Click here to view all cars."
 
       expect(current_url).to eq("http://www.example.com/cars")
@@ -61,7 +61,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     it 'should have a link to the dealerships index at the top' do
       visit "/dealerships/#{@dealership_1.id}/cars"
 
-      expect(page).to have_content("Click here to view all dealerships.")
+      expect(page).to have_link("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")
@@ -69,7 +69,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
 
     it 'should have a link to add a new car for that dealership' do
       visit "/dealerships/#{@dealership_1.id}/cars"
-      expect(page).to have_content("Add a new car.")
+      expect(page).to have_link("Add a new car.")
       click_link "Add a new car."
 
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/cars/new")
@@ -77,7 +77,7 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
 
     it 'should have a link to sort cars in alphabetical order' do
       visit "/dealerships/#{@dealership_2.id}/cars"
-      expect(page).to have_content("Sort in alphabetical order.")
+      expect(page).to have_link("Sort in alphabetical order.")
       click_link "Sort in alphabetical order."
 
       expect(current_path).to eq("/dealerships/#{@dealership_2.id}/cars")

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -45,11 +45,21 @@ RSpec.describe "/dealerships", type: :feature do
 
       expect(current_url).to eq("http://www.example.com/dealerships/new")
     end
+
+    it 'should have a link next to each dealership to edit its info' do
+        expect(page).to have_link("Click to edit #{@dealership_1.name}.")
+        click_link "Click to edit #{@dealership_1.name}."
+        expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/edit")
+
+        visit "/dealerships"
+        expect(page).to have_link("Click to edit #{@dealership_2.name}.")
+        click_link "Click to edit #{@dealership_2.name}."
+        expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/edit")
+
+        visit "/dealerships"
+        expect(page).to have_link("Click to edit #{@dealership_3.name}.")
+        click_link "Click to edit #{@dealership_3.name}."
+        expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_3.id}/edit")
+    end
   end
 end
-
-# As a visitor
-# When I visit the parent index page
-# Next to every parent, I see a link to edit that parent's info
-# When I click the link
-# I should be taken to that parent's edit page where I can update its information just like in User Story 12

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -26,24 +26,30 @@ RSpec.describe "/dealerships", type: :feature do
     end
 
     it 'should have a link to the cars index at the top' do
-      expect(page).to have_content("Click here to view all cars.")
+      expect(page).to have_link("Click here to view all cars.")
       click_link("Click here to view all cars.")
 
       expect(current_url).to eq("http://www.example.com/cars")
     end
 
     it 'should have a link to the dealerships index at the top' do
-      expect(page).to have_content("Click here to view all dealerships.")
+      expect(page).to have_link("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")
     end
 
     it 'should have a link to a page where you can create a dealership' do
-      expect(page).to have_content("New dealership.")
+      expect(page).to have_link("New dealership.")
       click_link "New dealership."
 
       expect(current_url).to eq("http://www.example.com/dealerships/new")
     end
   end
 end
+
+# As a visitor
+# When I visit the parent index page
+# Next to every parent, I see a link to edit that parent's info
+# When I click the link
+# I should be taken to that parent's edit page where I can update its information just like in User Story 12

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "/dealership/:id", type: :feature do
     it 'should have a link to the child index at the top' do
       visit "/dealerships/#{@dealership_1.id}"
 
-      expect(page).to have_content("Click here to view all cars.")
+      expect(page).to have_link("Click here to view all cars.")
       click_link("Click here to view all cars.")
 
       expect(current_url).to eq("http://www.example.com/cars")
@@ -40,7 +40,7 @@ RSpec.describe "/dealership/:id", type: :feature do
     it 'should have a link to the dealerships index at the top' do
       visit "/dealerships/#{@dealership_1.id}"
 
-      expect(page).to have_content("Click here to view all dealerships.")
+      expect(page).to have_link("Click here to view all dealerships.")
       click_link "Click here to view all dealerships."
 
       expect(current_url).to eq("http://www.example.com/dealerships")
@@ -48,24 +48,24 @@ RSpec.describe "/dealership/:id", type: :feature do
 
     it 'should have a link to the index of cars that belong to dealership' do
       visit "/dealerships/#{@dealership_1.id}"
-      expect(page).to have_content("Click here to view this dealership's inventory.")
+      expect(page).to have_link("Click here to view this dealership's inventory.")
       click_link "Click here to view this dealership's inventory."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/cars")
 
       visit "/dealerships/#{@dealership_2.id}"
-      expect(page).to have_content("Click here to view this dealership's inventory.")
+      expect(page).to have_link("Click here to view this dealership's inventory.")
       click_link "Click here to view this dealership's inventory."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/cars")
     end
 
     it 'has a link to update the dealership' do
       visit "/dealerships/#{@dealership_1.id}"
-      expect(page).to have_content("Update Dealership.")
+      expect(page).to have_link("Update Dealership.")
       click_link "Update Dealership."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_1.id}/edit")
 
       visit "/dealerships/#{@dealership_2.id}"
-      expect(page).to have_content("Update Dealership.")
+      expect(page).to have_link("Update Dealership.")
       click_link "Update Dealership."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/edit")
     end


### PR DESCRIPTION
User Story 17, Parent Update From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to edit that parent's info
When I click the link
I should be taken to that parent's edit page where I can update its information just like in User Story 12