### PR TITLE
18 user story

### DIFF
--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -1,5 +1,6 @@
 <% @cars.each do |car| %>
-<h3><%= "#{car.make} #{car.model}" %></h3>
+<h3><%= "#{car.make} #{car.model}" %>
+<%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %></h3>
 <p>AWD: <%= car.awd %></p>
 <p>Mileage: <%= car.mileage %></p>
 <% end %>

--- a/app/views/dealerships/cars/index.html.erb
+++ b/app/views/dealerships/cars/index.html.erb
@@ -1,5 +1,6 @@
   <% @cars.each do |car| %>
-    <h3><%= "#{car.make} #{car.model}" %></h3>
+    <h3><%= "#{car.make} #{car.model}" %>
+    <%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %></h3>
     <p>AWD? <%= car.awd %></p>
     <p>Mileage: <%= car.mileage %></p>
   <% end %>  

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -61,5 +61,17 @@ RSpec.describe "/cars", type: :feature do
       expect(page).to have_content(@car_4.awd)
       expect(page).to have_content(@car_4.mileage)
     end
+
+    it 'should have a link next to each car to edit its info' do
+      visit "/cars"
+      expect(page).to have_link("Click to edit #{@car_2.make} #{@car_2.model}.")
+      click_link "Click to edit #{@car_2.make} #{@car_2.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_2.id}/edit")
+
+      visit "/cars"
+      expect(page).to have_link("Click to edit #{@car_4.make} #{@car_4.model}.")
+      click_link "Click to edit #{@car_4.make} #{@car_4.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_4.id}/edit")
+    end
   end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -97,5 +97,27 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
 
       expect(@car_5.model).to appear_before(@car_6.model)
     end
+
+    it 'should have a link next to each car to edit its info' do
+      visit "/dealerships/#{@dealership_1.id}/cars"
+      expect(page).to have_link("Click to edit #{@car_1.make} #{@car_1.model}.")
+      click_link "Click to edit #{@car_1.make} #{@car_1.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_1.id}/edit")
+
+      visit "/dealerships/#{@dealership_1.id}/cars"
+      expect(page).to have_link("Click to edit #{@car_4.make} #{@car_4.model}.")
+      click_link "Click to edit #{@car_4.make} #{@car_4.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_4.id}/edit")
+
+      visit "/dealerships/#{@dealership_2.id}/cars"
+      expect(page).to have_link("Click to edit #{@car_2.make} #{@car_2.model}.")
+      click_link "Click to edit #{@car_2.make} #{@car_2.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_2.id}/edit")
+
+      visit "/dealerships/#{@dealership_2.id}/cars"
+      expect(page).to have_link("Click to edit #{@car_6.make} #{@car_6.model}.")
+      click_link "Click to edit #{@car_6.make} #{@car_6.model}."
+      expect(current_url).to eq("http://www.example.com/cars/#{@car_6.id}/edit")
+    end
   end
 end


### PR DESCRIPTION
User Story 18, Child Update From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14