### PR TITLE
19 user story

### DIFF
--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -34,4 +34,12 @@ class DealershipsController < ApplicationController
     dealership.save
     redirect_to "/dealerships/#{dealership.id}"
   end
+
+  def delete
+    dealership = Dealership.find(params[:dealership_id])
+    cars = dealership.list_cars(params)
+    cars.each{|car| car.destroy}
+    dealership.destroy
+    redirect_to '/dealerships'
+  end
 end

--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -6,3 +6,4 @@
   <p><%= @dealership.count_of_cars %> cars available</p>
 
 <p><%= link_to "Update Dealership.", "/dealerships/#{@dealership.id}/edit" %></p>
+<p><%= link_to "Delete Dealership.", "/dealerships/#{@dealership.id}", method: :delete %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   post '/dealerships/:dealership_id/cars', to: 'dealerships/cars#create'
   patch '/dealerships/:dealership_id', to: 'dealerships#update'
   patch '/cars/:car_id', to: 'cars#update'
+  delete '/dealerships/:dealership_id', to: 'dealerships#delete'
 end

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -69,5 +69,27 @@ RSpec.describe "/dealership/:id", type: :feature do
       click_link "Update Dealership."
       expect(current_url).to eq("http://www.example.com/dealerships/#{@dealership_2.id}/edit")
     end
+
+    it 'has a link to delete the dealership' do
+      visit "/dealerships/#{@dealership_1.id}"
+      expect(page).to have_link("Delete Dealership.")
+      click_link "Delete Dealership."
+      expect(current_path).to eq('/dealerships')
+      expect(page).to have_no_content(@dealership_1.name)
+    end
+
+    it 'deletes cars when their parent dealership is deleted' do
+      visit "/dealerships/#{@dealership_1.id}"
+      click_link "Delete Dealership."
+
+      visit "/cars"
+      expect(page).to have_no_content(@car_1.make)
+      expect(page).to have_no_content(@car_1.model)
+      expect(page).to have_no_content(@car_1.mileage)
+
+      expect(page).to have_no_content(@car_4.make)
+      expect(page).to have_no_content(@car_4.model)
+      expect(page).to have_no_content(@car_4.mileage)
+    end
   end
 end


### PR DESCRIPTION
As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent