### PR TITLE
20 user story

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -22,4 +22,10 @@ class CarsController < ApplicationController
     car.save
     redirect_to "/cars/#{car.id}"
   end
+
+  def delete
+    car = Car.find(params[:car_id])
+    car.destroy
+    redirect_to '/cars'
+  end
 end

--- a/app/views/cars/show.html.erb
+++ b/app/views/cars/show.html.erb
@@ -3,3 +3,4 @@
 <p>Mileage: <%= @car.mileage %></p>
 
 <p><%= link_to "Update Car.", "/cars/#{@car.id}/edit" %></p>
+<p><%= link_to "Delete Car.", "/cars/#{@car.id}", method: :delete %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   patch '/dealerships/:dealership_id', to: 'dealerships#update'
   patch '/cars/:car_id', to: 'cars#update'
   delete '/dealerships/:dealership_id', to: 'dealerships#delete'
+  delete '/cars/:car_id', to: 'cars#delete'
 end

--- a/spec/features/cars/show_spec.rb
+++ b/spec/features/cars/show_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "/cars/:id", type: :feature do
       @car_1 = Car.create!(make: 'Toyota', model: 'Corolla', awd: false, mileage: 30200, dealership_id: @dealership_1.id)
       @car_2 = Car.create!(make: 'Nissan', model: 'Rogue', awd: true, mileage: 46414, dealership_id: @dealership_2.id)
       @car_3 = Car.create!(make: 'Porsche', model: '911', awd: false, mileage: 160234, dealership_id: @dealership_3.id)
+      @car_4 = Car.create!(make: 'Jeep', model: 'Cherokee', awd: true, mileage: 67053, dealership_id: @dealership_2.id)
     end
     it "should display car with that id and its attributes" do
       visit "/cars/#{@car_1.id}"
@@ -57,6 +58,23 @@ RSpec.describe "/cars/:id", type: :feature do
       expect(page).to have_link("Update Car.")
       click_link "Update Car."
       expect(current_url).to eq("http://www.example.com/cars/#{@car_1.id}/edit")
+    end
+
+    it 'has a link to delete the car' do
+      visit "/cars/#{@car_1.id}"
+      expect(page).to have_link("Delete Car.")
+      click_link "Delete Car."
+      expect(current_path).to eq('/cars')
+      expect(page).to have_no_content(@car_1.model)
+
+      visit "/cars/#{@car_2.id}"
+      expect(page).to have_link("Delete Car.")
+      click_link "Delete Car."
+      expect(current_path).to eq('/cars')
+      expect(page).to have_no_content(@car_2.model)
+      expect(page).to have_content(@car_4.make)
+      expect(page).to have_content(@car_4.model)
+      expect(page).to have_content(@car_4.mileage)
     end
   end
 end

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe "/dealership/:id", type: :feature do
       expect(page).to have_no_content(@car_4.make)
       expect(page).to have_no_content(@car_4.model)
       expect(page).to have_no_content(@car_4.mileage)
+
+      expect(page).to have_content(@car_5.make)
+      expect(page).to have_content(@car_5.model)
+      expect(page).to have_content(@car_5.mileage)
     end
   end
 end


### PR DESCRIPTION
User Story 20, Child Delete 

As a visitor
When I visit a child show page
Then I see a link to delete the child "Delete Child"
When I click the link
Then a 'DELETE' request is sent to '/child_table_name/:id',
the child is deleted,
and I am redirected to the child index page where I no longer see this child