### PR TITLE
21 user story

### DIFF
--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -8,4 +8,9 @@ class Car < ApplicationRecord
   def self.sort_alphabetically
     Car.order(:make, :model)
   end
+
+  def self.filter_by_mileage(mileage)
+    miles = mileage.delete(',').to_i
+    Car.where("mileage > #{miles}")
+  end
 end

--- a/app/models/dealership.rb
+++ b/app/models/dealership.rb
@@ -5,6 +5,8 @@ class Dealership < ApplicationRecord
     dealership_cars = Car.where(dealership_id: id)
     if params[:sort] == "alphabetically"
       @cars = dealership_cars.sort_alphabetically
+    elsif params[:commit] == "Filter"
+      @cars = dealership_cars.filter_by_mileage(params[:mileage])
     else
       @cars = dealership_cars.all
     end

--- a/app/views/dealerships/cars/index.html.erb
+++ b/app/views/dealerships/cars/index.html.erb
@@ -8,3 +8,8 @@
 <p><%= link_to "Add a new car.", "/dealerships/#{@dealership.id}/cars/new" %></p><br>
 
 <p><%= link_to "Sort in alphabetical order.", "/dealerships/#{@dealership.id}/cars?sort=alphabetically" %></p><br>
+
+<p>Show me cars with over:<%= form_with url: "/dealerships/#{@dealership.id}/cars", method: :get, local: true do |form| %>
+<%= form.text_field :mileage %> miles.
+<%= form.submit "Filter" %>
+<% end %></p>

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -138,9 +138,3 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
     end
   end
 end
-
-# As a visitor
-# When I visit the Parent's children Index Page
-# I see a form that allows me to input a number value
-# When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
-# Then I am brought back to the current index page with only the records that meet that threshold shown.

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -119,5 +119,28 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
       click_link "Click to edit #{@car_6.make} #{@car_6.model}."
       expect(current_url).to eq("http://www.example.com/cars/#{@car_6.id}/edit")
     end
+
+    it 'has a form that allows me to only see cars over a mileage I specify' do
+      visit "/dealerships/#{@dealership_1.id}/cars"
+      expect(page).to have_field("mileage")
+      expect(page).to have_content("Show me cars with over:")
+      expect(page).to have_content("miles.")
+      fill_in(:mileage, with: '65,000')
+      click_button('Filter')
+
+      expect(current_path).to eq("/dealerships/#{@dealership_1.id}/cars")
+      expect(page).to have_content(@car_4.model)
+      expect(page).to have_content(@car_4.mileage)
+      expect(page).to have_content(@car_7.model)
+      expect(page).to have_content(@car_7.mileage)
+      expect(page).to have_no_content(@car_1.model)
+      expect(page).to have_no_content(@car_1.mileage)
+    end
   end
 end
+
+# As a visitor
+# When I visit the Parent's children Index Page
+# I see a form that allows me to input a number value
+# When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
+# Then I am brought back to the current index page with only the records that meet that threshold shown.

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -29,5 +29,12 @@ RSpec.describe Car, type: :model do
         assert_equal(results, expected)
       end
     end
+    describe '::filter_by_mileage' do
+      it 'returns an array of cars that are above given mileage' do
+        results = Car.filter_by_mileage("80,000")
+        expected = [@car_3, @car_4]
+        assert_equal(results, expected)
+      end
+    end
   end
 end

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Dealership, type: :model do
         expected = [@car_5,@car_2,@car_3]
         assert_equal(results, expected)
       end
+      it 'returns filtered list of cars based on specified mileage' do
+        params = {commit: "Filter", mileage: "65,000"}
+        results = @dealership_1.list_cars(params)
+        expected = [@car_4]
+        assert_equal(results, expected)
+
+        results = @dealership_2.list_cars(params)
+        expected = [@car_3,@car_5]
+        assert_equal(results, expected)
+      end
       it 'returns list of cars without query' do
         params = {blank: "blank"}
         results = @dealership_1.list_cars(params)


### PR DESCRIPTION
User Story 21, Display Records Over a Given Threshold 

As a visitor
When I visit the Parent's children Index Page
I see a form that allows me to input a number value
When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
Then I am brought back to the current index page with only the records that meet that threshold shown.