### PR TITLE
23 user story

### DIFF
--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -1,6 +1,7 @@
 <% @cars.each do |car| %>
 <h3><%= "#{car.make} #{car.model}" %>
-<%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %></h3>
+<%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %>
+<%= link_to "Delete #{car.make} #{car.model}.", "/cars/#{car.id}", method: :delete %></p></h3>
 <p>AWD: <%= car.awd %></p>
 <p>Mileage: <%= car.mileage %></p>
 <% end %>

--- a/app/views/dealerships/cars/index.html.erb
+++ b/app/views/dealerships/cars/index.html.erb
@@ -1,6 +1,8 @@
   <% @cars.each do |car| %>
     <h3><%= "#{car.make} #{car.model}" %>
-    <%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %></h3>
+    <%= link_to "Click to edit #{car.make} #{car.model}.", "/cars/#{car.id}/edit" %>
+    <%= link_to "Delete #{car.make} #{car.model}.", "/cars/#{car.id}", method: :delete %></p></h3>
+    </h3>
     <p>AWD? <%= car.awd %></p>
     <p>Mileage: <%= car.mileage %></p>
   <% end %>  

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -73,5 +73,24 @@ RSpec.describe "/cars", type: :feature do
       click_link "Click to edit #{@car_4.make} #{@car_4.model}."
       expect(current_url).to eq("http://www.example.com/cars/#{@car_4.id}/edit")
     end
+
+    it 'should have a link next to each car to delete its info' do
+      expect(page).to have_link("Delete #{@car_2.make} #{@car_2.model}.")
+      click_link "Delete #{@car_2.make} #{@car_2.model}."
+      expect(current_path).to eq('/cars')
+      expect(page).to have_no_content(@car_2.make)
+      expect(page).to have_no_content(@car_2.model)
+      expect(page).to have_no_content(@car_2.mileage)
+      expect(page).to have_content(@car_4.make)
+      expect(page).to have_content(@car_4.model)
+      expect(page).to have_content(@car_4.mileage)
+
+      expect(page).to have_link("Delete #{@car_4.make} #{@car_4.model}.")
+      click_link "Delete #{@car_4.make} #{@car_4.model}."
+      expect(current_path).to eq('/cars')
+      expect(page).to have_no_content(@car_4.make)
+      expect(page).to have_no_content(@car_4.model)
+      expect(page).to have_no_content(@car_4.mileage)
+    end
   end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -136,5 +136,24 @@ RSpec.describe "/dealerships/:id/cars", type: :feature do
       expect(page).to have_no_content(@car_1.model)
       expect(page).to have_no_content(@car_1.mileage)
     end
+
+    it 'should have a link next to each car to delete its info' do
+      visit "/dealerships/#{@dealership_1.id}/cars"
+
+      expect(page).to have_link("Delete #{@car_7.make} #{@car_7.model}.")
+      click_link "Delete #{@car_7.make} #{@car_7.model}."
+      expect(current_path).to eq("/cars")
+      expect(page).to have_no_content(@car_7.make)
+      expect(page).to have_no_content(@car_7.model)
+      expect(page).to have_no_content(@car_7.mileage)
+
+      visit "/dealerships/#{@dealership_2.id}/cars"
+
+      expect(page).to have_link("Delete #{@car_6.make} #{@car_6.model}.")
+      click_link "Delete #{@car_6.make} #{@car_6.model}."
+      expect(current_path).to eq("/cars")
+      expect(page).to have_no_content(@car_6.model)
+      expect(page).to have_no_content(@car_6.mileage)
+    end
   end
 end


### PR DESCRIPTION
User Story 23, Child Delete From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to delete that child
When I click the link
I should be taken to the `child_table_name` index page where I no longer see that child